### PR TITLE
Fix link typo

### DIFF
--- a/website/core/CookieBanner/index.js
+++ b/website/core/CookieBanner/index.js
@@ -19,7 +19,7 @@ const CookieBanner = () => {
       <div className="wrapper">
         <p>To help us provide relevant content, analyze our traffic, and provide a variety of features, we use cookies. By clicking on or navigating the site, you agree to allow us to collect information on and off the Libra Website through cookies. To learn more, view our Cookie Policy:</p>
         <div className="buttonWrapper">
-          <a className="button" href={'docs/policies/cookies-policy'} target="_blank">
+          <a className="button" href={'policies/cookies-policy'} target="_blank">
             Cookies Policy
           </a>
         </div>


### PR DESCRIPTION
## Motivation

For pages in Documentation link on Cookies Policy is broken: https://developers.libra.org/docs/docs/policies/cookies-policy

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instrutions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
