### PR TITLE
Fix merkle tree image in Storage docs

### DIFF
--- a/docs/crates/storage.md
+++ b/docs/crates/storage.md
@@ -21,7 +21,7 @@ The storage module is designed to serve two primary purposes:
 The Libra Blockchain can be viewed as a Merkle tree consisting of the following
 components:
 
-![data](assets/data.png)
+![data](../assets/data.png)
 
 ### Ledger History
 


### PR DESCRIPTION
## Motivation

Fixing the Merkle tree image on the Storage page

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/master/CONTRIBUTING.md#pull-requests)?

yes


