### PR TITLE
Fixing missing command for query account_state

### DIFF
--- a/docs/my-first-transaction.md
+++ b/docs/my-first-transaction.md
@@ -468,6 +468,7 @@ Last event state: Some(
 In this example, we will query for the state of a single account.
 
 ```plaintext
+libra% query account_state 0
 >> Getting latest account state
 Latest account state is:
  Account: 3ed8e5fafae4147b2a105a0be2f81972883441cfaaadf93fc0868e7a0253c4a8


### PR DESCRIPTION
Documentation was missing sample command for `libra% query account_state 0`.
