### PR TITLE
make users consistent

### DIFF
--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -82,7 +82,7 @@ A **client** is a piece of software that has the capability to interact with the
 
 * It can allow the user to construct, sign, and submit new transactions to the admission control component of a validator node.
 * It can issue queries to the Libra Blockchain and request the status of a transaction or account.
-* A client can be run by the end-user or on behalf of the end user (for example, for a custodial wallet). 
+* A client can be run by the user or on behalf of the user (for example, for a custodial wallet). 
 
 ### Consensus
 


### PR DESCRIPTION
A minor consistency suggestion: with a dozen or so uses of "user" in the glossary, it seems odd to start using "end-user" and also "end user" in this section.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instrutions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
