### PR TITLE
LIB-8: Removed the stylesheets from the config

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -81,14 +81,6 @@ const siteConfig = {
      // `${baseUrl}js/search.js`,
   ],
 
-  // CSS sources to load
-  stylesheets: [
-    `${baseUrl}css/code_block_buttons.css`,
-    `${baseUrl}css/fonts/NBInternationalProEditionWeb/stylesheet.css`,
-    `${baseUrl}katex-dist/katex.min.css`,
-    `${baseUrl}css/search.css`,
-  ],
-
   // Custom markdown functions
   markdownPlugins: markdownPlugins,
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation
This will fix the 404s for the stylesheets. It seems like the `stylesheets` config object is better used for importing external css. All the stylesheets in the static directory are [concatenated](https://github.com/facebook/docusaurus/blob/166816af40bd14ec851472bc99921815962f72f1/packages/docusaurus-1.x/lib/server/generate.js#L226) to the `main.css` file on build, but all the stylesheets in the `siteConfig.js` are also [added to the Head](https://github.com/facebook/docusaurus/blob/9514593d5f89275760ab0ad93dc12d8f80e0f65c/packages/docusaurus-1.x/lib/core/Head.js#L136).

You can use the siteConfig's `separateCss` property but you then need to change up your directory structure. Any overrides to the main css cannot be in the `separateCss` directories.

Here are a few pages that show the styles are loaded correctly:

https://docusaurus-example.s3-us-west-2.amazonaws.com/index.html
https://docusaurus-example.s3-us-west-2.amazonaws.com/docs/welcome-to-libra.html
https://docusaurus-example.s3-us-west-2.amazonaws.com/newsletter_form/index.html

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan


## Related PRs

