### PR TITLE
Update dev site pages to use LBR symbol and misc. style edits.

### DIFF
--- a/docs/libra-protocol.md
+++ b/docs/libra-protocol.md
@@ -6,23 +6,23 @@ title: Libra Protocol: Key Concepts
 
 The Libra Blockchain is a cryptographically authenticated distributed database, and it is based on the Libra protocol. This document briefly describes the key concepts of the Libra protocol. For a detailed description of all the elements of the Libra protocol, refer to the [Libra Blockchain technical paper](https://libra.org/en-us/whitepaper).
 
-The Libra Blockchain is maintained by a distributed network of [validator nodes](reference/glossary.md#validator-node), also known as validators. The validators collectively follow a [consensus protocol](reference/glossary.md#consensus-protocol) to agree on an ordering of transactions in the blockchain. 
+The Libra Blockchain is maintained by a distributed network of [validator nodes](reference/glossary.md#validator-node), also known as validators. The validators collectively follow a [consensus protocol](reference/glossary.md#consensus-protocol) to agree on an ordering of transactions in the blockchain.
 
 The Libra testnet is a demonstration of an early prototype of the Libra Blockchain software — Libra Core.
 
 ## Transactions and States
 
-At the heart of the Libra protocol are two fundamental concepts &mdash; transactions and states. At any point in time, the blockchain has a “state.” The state (or ledger state) represents the current snapshot of data on the chain. Executing a transaction changes the state of the blockchain. 
+At the heart of the Libra protocol are two fundamental concepts &mdash; transactions and states. At any point in time, the blockchain has a “state.” The state (or ledger state) represents the current snapshot of data on the chain. Executing a transaction changes the state of the blockchain.
 
 ![Figure 1.1 A transaction changes state.](assets/illustrations/transactions.svg)
 <small class="figure">Figure 1.1 Transactions change state.</small>
 
-Figure 1.1 represents the change of state of the Libra Blockchain that occurs when a transaction is executed. For example, at state S~N-1~, Alice has a balance of 110 Libra, and Bob has a balance of 52 Libra. When a transaction is applied to the blockchain, it generates a new state. To transition from S~N-1~ to S~N~, transaction T~N~ is applied against the state S~N-1~. This causes Alice’s balance to be reduced by 10 Libra and Bob’s balance to be increased by 10 Libra. The new state S~N~ now shows these updated balances. In figure 1.1:
+Figure 1.1 represents the change of state of the Libra Blockchain that occurs when a transaction is executed. For example, at state S~N-1~, Alice has a balance of 110 LBR, and Bob has a balance of 52 LBR. When a transaction is applied to the blockchain, it generates a new state. To transition from S~N-1~ to S~N~, transaction T~N~ is applied against the state S~N-1~. This causes Alice’s balance to be reduced by 10 LBR and Bob’s balance to be increased by 10 LBR. The new state S~N~ now shows these updated balances. In figure 1.1:
 
 * **A** and **B** represent Alice’s and Bob’s accounts in the blockchain.
 * **S~N-1~** represents the (N-1)^th^ state of the blockchain.
 * **T~N~** is the n-th transaction executed on the blockchain.  
-    * In this example, T~N~ is - “send 10 Libra from person A’s account to person B’s account.”
+    * In this example, T~N~ is - “send 10 LBR from person A’s account to person B’s account.”
 * **F** is a deterministic function. F always returns the same final state for a specific initial state and a specific transaction. If the current state of the blockchain is S~N-1~, and transaction T~N~ is executed on state S~N-1~, the new state of the blockchain is always S~N~.
 * **S~N~** is the n-th state of the blockchain. S~N~ is an outcome of applying F to S~N-1~ and T~N~.
 
@@ -37,14 +37,14 @@ Clients of the Libra Blockchain submit transactions to request updates to the le
 * **Program** &mdash; The program is comprised of the following:
     * A Move bytecode transaction script.
     * An optional list of inputs to the script. For a peer-to-peer transaction, the inputs contain the information about the recipient and the amount transferred to the recipient.
-    * An optional list of Move bytecode modules to publish. 
+    * An optional list of Move bytecode modules to publish.
 * **Gas price** (in microlibra/gas units) &mdash; The amount the sender is willing to pay per unit of [gas](reference/glossary.md#gas) to execute the transaction. Gas is a way to pay for computation and storage. A gas unit is an abstract measurement of computation with no inherent real-world value.
 * **Maximum gas amount** &mdash; The maximum units of gas the transaction is allowed to consume.
 * **Sequence number** &mdash; An unsigned integer that must be equal to the sequence number stored under the sender’s account.
 * **Expiration time** &mdash; The time after which the transaction ceases to be valid.
 * **Signature** &mdash; The digital signature of the sender.
 
-The transaction script is an arbitrary program that encodes the logic of a transaction and interacts with resources published in the distributed database of the Libra Blockchain. 
+The transaction script is an arbitrary program that encodes the logic of a transaction and interacts with resources published in the distributed database of the Libra Blockchain.
 
 ### Ledger State
 
@@ -61,7 +61,7 @@ The versioned database allows validators to:
 
 ## Account
 
-A Libra account is a container for Move modules and Move resources. It is identified by an [account address](reference/glossary.md#account-address). This essentially means that the state of each account is comprised of both code and data: 
+A Libra account is a container for Move modules and Move resources. It is identified by an [account address](reference/glossary.md#account-address). This essentially means that the state of each account is comprised of both code and data:
 
 * **[Move modules](move-overview.md#move-modules-allow-composable-smart-contracts)** contain code (type and procedure declarations), but they do not contain data. The procedures of a module encode the rules for updating the global state of the blockchain.
 * **[Move resources](move-overview.md#move-has-first-class-resources)** contain data but no code. Every resource value has a type that is declared in a module published in the distributed database of the blockchain.
@@ -78,7 +78,7 @@ There is no limit on the number of addresses a Libra user can claim. To claim an
 
 All of the data in the Libra Blockchain is stored in a single-versioned distributed database. The storage is used to persist agreed upon blocks of transactions and their execution results. The blockchain is represented as an ever-growing [Merkle tree of transactions](reference/glossary.md#merkle-trees). A “leaf” is appended to the tree for each transaction executed on the blockchain.
 
-* A proof is a way to verify the truth of data in the Libra Blockchain. 
+* A proof is a way to verify the truth of data in the Libra Blockchain.
 * Every operation stored on the blockchain can be verified cryptographically, and the resultant proof also proves that no data has been omitted. For example, if the client queried the latest _n_ transactions from an account, the proof verifies that no transactions are omitted from the query response.
 
 In a blockchain, the client does not need to trust the entity from which it is receiving data. A client could query for the balance of an account, ask whether a specific transaction was processed, and so on. As with other Merkle trees, the ledger history can provide an $O(\log n)$-sized proof of a specific transaction object, where _n_ is the total number of transactions processed.
@@ -93,13 +93,13 @@ Clients of the Libra Blockchain create transactions and submit them to a validat
 
 **Admission Control (AC)**
 
-* Admission Control is the sole external interface of the validator node. Any request made by a client to the validator node goes to AC first. 
+* Admission Control is the sole external interface of the validator node. Any request made by a client to the validator node goes to AC first.
 * AC performs initial checks on the requests to protect the other parts of the validator node from corrupt or high volume input.
 
 **Mempool**
 
-* Mempool is a buffer that holds the transactions that are “waiting” to be executed. 
-* When a new transaction is added to a validator node’s mempool, this validator node’s mempool shares this transaction with the mempools of other validators in the system. 
+* Mempool is a buffer that holds the transactions that are “waiting” to be executed.
+* When a new transaction is added to a validator node’s mempool, this validator node’s mempool shares this transaction with the mempools of other validators in the system.
 
 **Consensus**
 

--- a/docs/life-of-a-transaction.md
+++ b/docs/life-of-a-transaction.md
@@ -7,7 +7,7 @@ To get a deeper understanding of the lifecycle of a Libra transaction, we will f
 
 ## Client Submits a Transaction
 
-A Libra **client constructs a raw transaction** (let us call it T~5~raw) to transfer 10 Libra from Alice’s account to Bob’s account. The raw transaction includes the following fields. Each field is linked to its glossary definition.
+A Libra **client constructs a raw transaction** (let us call it T~5~raw) to transfer 10 LBR from Alice’s account to Bob’s account. The raw transaction includes the following fields. Each field is linked to its glossary definition.
 
 * Alice's [account address](reference/glossary.md#account-address).
 * A program that indicates the actions to be performed on Alice's behalf. It contains:
@@ -30,7 +30,7 @@ The **client signs transaction** T~5~raw with Alice's private key. The signed tr
 To describe the lifecycle of transaction T~5~, we will assume that:
 
 * Alice and Bob have [accounts](reference/glossary.md#accounts) on the Libra Blockchain.
-* Alice's account has 110 Libra.
+* Alice's account has 110 LBR.
 * The current [sequence number](reference/glossary.md#sequence-number) of Alice's account is 5 (which indicates that 5 transactions have already been sent from Alice's account).
 * There are a total of 100 validators &mdash; V~1~ to V~100~ on the network.
 * The client submits transaction T~5~ to validator V~1~
@@ -84,7 +84,7 @@ Where relevant, and following a numbered step in the lifecycle, we have provided
 
 **12** &mdash; If the block's execution result is agreed upon and signed by a set of validators that have the super-majority of votes, validator V~1~'s execution component reads the result of the block execution from the speculative execution cache and commits all the transactions in the block to persistent storage. (Consensus → Execution [CO.4](#consensus-execution-co4), [EX.3](#consensus-execution-ex3)), (Execution → Storage [EX.4](#execution-storage-ex4), [ST.3](#execution-storage-st3))
 
-**13** &mdash; Alice's account will now have 100 Libra, and its sequence number will be 6. If T~5~ is replayed by Bob, it will be rejected as the sequence number of Alice's account (6) is greater than the sequence number of the replayed transaction (5).
+**13** &mdash; Alice's account will now have 100 LBR, and its sequence number will be 6. If T~5~ is replayed by Bob, it will be rejected as the sequence number of Alice's account (6) is greater than the sequence number of the replayed transaction (5).
 
 ## Validator Component Interactions
 

--- a/docs/my-first-transaction.md
+++ b/docs/my-first-transaction.md
@@ -142,7 +142,7 @@ Sample output on success:
 Created/retrieved account #0 address 3ed8e5fafae4147b2a105a0be2f81972883441cfaaadf93fc0868e7a0253c4a8
 ```
 
-#0 is the index of Alice’s account, and the hex string is the address of Alice’s account. The index is just a way to refer to Alice’s account. The account index is a local CLI index that can be used in other CLI commands for users to conveniently refer to the accounts they have created. The index is meaningless to the blockchain. Alice’s account will be created on the blockchain only when either money is added to Alice’s account via minting, or money is transferred to Alice’s account via a transfer from another user. Note that you may also use the hex address in CLI commands. The account index is just a convenience wrapper around the account address.
+0 is the index of Alice’s account, and the hex string is the address of Alice’s account. The index is just a way to refer to Alice’s account. The account index is a local CLI index that can be used in other CLI commands for users to conveniently refer to the accounts they have created. The index is meaningless to the blockchain. Alice’s account will be created on the blockchain only when either money is added to Alice’s account via minting, or money is transferred to Alice’s account via a transfer from another user. Note that you may also use the hex address in CLI commands. The account index is just a convenience wrapper around the account address.
 
 ### Step 3: Create Bob’s Account
 
@@ -157,7 +157,7 @@ Sample output on success:
 Created/retrieved account #1 address 8337aac709a41fe6be03cad8878a0d4209740b1608f8a81566c9a7d4b95a2ec7
 ```
 
-#1 is the index for Bob’s account, and the hex string is the address of Bob’s account.
+1 is the index for Bob’s account, and the hex string is the address of Bob’s account.
 For more details on index refer to [Create Alice’s Account.](#step-2-create-alice-s-account)
 
 ### Step 4 (Optional): List Accounts
@@ -177,7 +177,7 @@ The sequence number for an account indicates the number of transactions that hav
 
 Minting and adding coins to accounts on testnet is done via Faucet. Faucet is a service that runs along with the testnet. This service only exists to facilitate minting coins for testnet and will not exist for [mainnet](reference/glossary.md#mainnet). It creates Libra with no real-world value. Assuming you have [created Alice’s and Bob’s account](#create-alice-s-and-bob-s-account), with index 0 and index 1 respectively, you can follow the steps below to add Libra to both accounts.
 
-### Step 1: Add 110 Libra to Alice’s Account
+### Step 1: Add 110 LBR to Alice’s Account
 
 To mint Libra and add to Alice’s account, enter this command:
 
@@ -199,7 +199,7 @@ Note that when the request is submitted, it means that it has been added to the 
 If your account mint command did not submit your request successfully, refer to
 [Troubleshooting](#minting-and-adding-money-to-account)
 
-### Step 2: Add 52 Libra to Bob’s Account
+### Step 2: Add 52 LBR to Bob’s Account
 
 To mint Libra and add to Bob’s account, enter this command:
 
@@ -255,7 +255,7 @@ In `query sequence 0`, 0 is the index of Alice’s account. A sequence number of
 
 ### Transfer Money
 
-To submit a transaction to transfer 10 Libra from Alice’s account to Bob’s account, enter this command:
+To submit a transaction to transfer 10 LBR from Alice’s account to Bob’s account, enter this command:
 
 `libra% transfer 0 1 10`
 
@@ -298,7 +298,7 @@ The sequence number of 1 for Alice’s account (index 0) indicates that one tran
 
 ### Check the Balance in Both Accounts After Transfer
 
-To check the final balance in both accounts, query the balance again for each account as you did in [this step](#step-3-check-the-balance). If your transaction (transfer) executed successfully, you should see 100 Libra in Alice’s account and 62 Libra in Bob’s account.
+To check the final balance in both accounts, query the balance again for each account as you did in [this step](#step-3-check-the-balance). If your transaction (transfer) executed successfully, you should see 100 LBR in Alice’s account and 62 LBR in Bob’s account.
 
 ```plaintext
 libra% query balance 0
@@ -309,7 +309,7 @@ Balance is: 62
 
 ### Congratulations!
 
-You have successfully executed your transaction on the Libra testnet and transferred 10 Libra from Alice’s account to Bob’s account!
+You have successfully executed your transaction on the Libra testnet and transferred 10 LBR from Alice’s account to Bob’s account!
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

* Use the LBR symbol instead of the word "libra." For example, instead of saying 10 libra say 10 LBR.
* Misc Updates: To mention the index of Alice's and Bob's account, use the numbers 0 and 1 without the # sign.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Review
## Related PRs

None
