### PR TITLE
adding troubleshooting info for zlib dev packages

### DIFF
--- a/docs/my-first-transaction.md
+++ b/docs/my-first-transaction.md
@@ -319,6 +319,9 @@ You have successfully executed your transaction on the Libra testnet and transfe
     * Run `rustup update` from your libra directory.
 * Update protoc:
     * Update `protoc` to version 3.6.0 or above.
+* Install zlib development packages
+    * `apt install zlib1g-dev` (Debian, Ubuntu, etc)
+    * `yum install zlib-devel` (CentOS, Fedora, etc)
 * Re-run setup script from your libra directory:
     * `./scripts/dev_setup.sh`
 


### PR DESCRIPTION
My experience is that the build fails if the zlib dev packages are not previously installed. 

This of course should be added to the installer scripts themselves, but I am new to this project and want to start with a suggestion rather than a change to code.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

I want everyone to have a easy build process, if others are experiencing the same showstoppers as I am, the can try what I tried.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes. As this is documentation, and a extra section at that, I feel confident I do not need linting, unit tests, etc.

## Test Plan

I will go back and test this manually with a few default MIs from GCE and AWS.

## Related PRs


