### PR TITLE
Changing Bug Bounty's link to Libra's program page

### DIFF
--- a/docs/policies/security.md
+++ b/docs/policies/security.md
@@ -13,7 +13,7 @@ The Libra team and community take all security bugs in the Libra project
 seriously to ensure the security of the Libra Blockchain.
 
 
-Please report security bugs on [Libra’s Bug Bounty with HackerOne](https://hackerone.com/users/sign_in).
+Please report security bugs on [Libra’s Bug Bounty with HackerOne](https://hackerone.com/libra).
 
 You can also report security bugs by emailing us directly at [security@libra.org](mailto:security@libra.org).
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

The previous Bug Bounty link landed to the login page. This PR lands to the Libra's program page.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.