### PR TITLE
[website] Modify transaction descriptions and remove double spaces

### DIFF
--- a/docs/life-of-a-transaction.md
+++ b/docs/life-of-a-transaction.md
@@ -5,7 +5,7 @@ title: Life of a Transaction
 
 To get a deeper understanding of the lifecycle of a Libra transaction, we will follow a transaction on its journey from being submitted to a Libra validator to being committed to the Libra Blockchain. We will then “zoom-in” on each logical component of a validator and take a look at its interactions with other components.
 
-## Client Submits a Transaction
+## Client Submits a Peer-To-Peer Transaction
 
 A Libra **client constructs a raw transaction** (let us call it T~5~raw) to transfer 10 LBR from Alice’s account to Bob’s account. The raw transaction includes the following fields. Each field is linked to its glossary definition.
 
@@ -93,7 +93,7 @@ In the [previous section](#lifecycle-of-the-transaction), we described the typic
 * Would like to get an overall idea of how the system works under the covers.
 * Are interested in eventually contributing to the Libra Core software.
 
-For our narrative, we will assume that a client submits a  transaction T~N~ to a validator V~X~. For each validator component, we will describe each of its inter-component interactions in subsections under the respective component's section. Note that subsections describing the inter-component interactions are not listed strictly in the order in which they are performed. Most of the interactions are relevant to the processing of a transaction, and a few are relevant to read queries by the client (queries for existing information on the blockchain).
+For our narrative, we will assume that a client submits a transaction T~N~ to a validator V~X~. For each validator component, we will describe each of its inter-component interactions in subsections under the respective component's section. Note that subsections describing the inter-component interactions are not listed strictly in the order in which they are performed. Most of the interactions are relevant to the processing of a transaction, and a few are relevant to read queries by the client (queries for existing information on the blockchain).
 
  Let us look at the core logical components of a validator node:
 
@@ -115,7 +115,7 @@ Admission Control is the _sole external interface_ of the validator. Any request
 
 ### Client → AC (AC.1)
 
-A client submits a  transaction to the admission control of a validator V~X~. This is done via:
+A client submits a transaction to the admission control of a validator V~X~. This is done via:
 `AC::SubmitTransaction()`.
 
 ### AC → VM (AC.2)
@@ -152,7 +152,7 @@ When AC or mempool request the VM to validate a transaction via `VM::ValidateTra
 
 * Checks that the input signature on the signed transaction is correct (to reject incorrectly signed transactions).
 * Checks that the sender's account authentication key is the same as the hash of the public key (corresponding to the private key used to sign the transaction).
-* Verifies that the sequence number for the transaction is not less than the current sequence number for the sender's account.  Doing this check prevents the replay of the same transaction against the sender's account.
+* Verifies that the sequence number for the transaction is not less than the current sequence number for the sender's account. Doing this check prevents the replay of the same transaction against the sender's account.
 * Verifies that the program in the signed transaction is not malformed, as a malformed program cannot be executed by the VM.
 * Verifies that there is sufficient balance in the sender's account to support the max gas amount specified in the transaction, which ensures that the transaction can pay for the resources it uses.
 
@@ -238,7 +238,7 @@ Execution's job is to coordinate the execution of a block of transactions and ma
 
 ### Consensus → Execution (EX.1)
 
-*  Consensus requests execution to execute a block of transactions via: `Execution::ExecuteBlock()`.
+* Consensus requests execution to execute a block of transactions via: `Execution::ExecuteBlock()`.
 * Execution maintains a “scratchpad,” which holds in-memory copies of the relevant portions of the [Merkle accumulators](#merkle-accumulators). This information is used to calculate the root hash of the current state of the blockchain.
 * The root hash of the current state is combined with the information about the transactions in the block to determine the new root hash of the accumulator. This is done prior to persisting any data, and to ensure that no state or transaction is stored until agreement is reached by a quorum of validators.
 * Execution computes the speculative root hash and then consensus of V~X~ signs this root hash and attempts to reach agreement on this root hash with other validators.
@@ -249,7 +249,7 @@ When consensus requests execution to execute a block of transactions via `Execut
 
 ### Consensus → Execution (EX.3)
 
-If a quorum of validators agrees on the block execution results, consensus of each validator informs its execution component via `Execution::CommitBlock()` that this block is ready to be committed.  This call to the execution component will include the signatures of the agreeing validators to provide proof of their agreement.
+If a quorum of validators agrees on the block execution results, consensus of each validator informs its execution component via `Execution::CommitBlock()` that this block is ready to be committed. This call to the execution component will include the signatures of the agreeing validators to provide proof of their agreement.
 
 ### Execution → Storage (EX.4)
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -10,7 +10,7 @@ title: Glossary
 
 ### Accumulator Root Hash
 
-* An **accumulator root hash** is the root hash of a [Merkle accumulator.](https://eprint.iacr.org/2009/625.pdf) 
+* An **accumulator root hash** is the root hash of a [Merkle accumulator.](https://eprint.iacr.org/2009/625.pdf)
 
 ### Access path
 
@@ -28,20 +28,20 @@ title: Glossary
 * The **address** of a Libra account is a 256-bit value.
 * Users can create an address by generating a cryptographic key-pair.
 * The account address is a cryptographic hash of a user's public verification key.
-* There is no limit on the number of addresses a Libra user can create. 
+* There is no limit on the number of addresses a Libra user can create.
 
 ### Admission Control (AC)
 
-* In Libra Core, **admission control** is the sole external interface to the validator.  Any incoming request (transaction submission or queries) from a client goes through admission control. A client does not have the ability to access the storage, or any other component in the system, without going through AC.  This filters requests and protects the system.
+* In Libra Core, **admission control** is the sole external interface to the validator. Any incoming request (transaction submission or queries) from a client goes through admission control. A client does not have the ability to access the storage, or any other component in the system, without going through AC. This filters requests and protects the system.
 
-* AC is a validator's entry point for all client interactions.  It performs basic validity checks on a submitted transaction. After completing validity checks, it passes the transaction to [mempool](#mempool).
+* AC is a validator's entry point for all client interactions. It performs basic validity checks on a submitted transaction. After completing validity checks, it passes the transaction to [mempool](#mempool).
 
 * A client will use AC for submitting transactions and performing queries (reads).
 
 ### Authentication Key
 
-* An **authentication key** is used to authenticate the cryptographic key used to sign a transaction. 
-* It is a piece of data stored in the user's account on the blockchain. 
+* An **authentication key** is used to authenticate the cryptographic key used to sign a transaction.
+* It is a piece of data stored in the user's account on the blockchain.
 * Users can rotate their signing key by rotating their authentication key.
 
 ## B
@@ -50,7 +50,7 @@ title: Glossary
 
 ### Block
 
-* A **block** is an ordered list of one or more transactions. It is used by validators to reach consensus on the ordering and execution results of the transactions. 
+* A **block** is an ordered list of one or more transactions. It is used by validators to reach consensus on the ordering and execution results of the transactions.
 * Blocks are an internal implementation concept in the Libra Blockchain, i.e., they are not visible to the client. All transactions that are committed to the Libra ledger were part of a block at some point in time, however the blockchain is represented as a sequence of transactions.
 
 ### Blockchain
@@ -65,9 +65,9 @@ title: Glossary
 
 ### Byzantine Fault Tolerance (BFT)
 
-* **Byzantine Fault Tolerance** (BFT) is the ability of a distributed system to provide safety and liveness guarantees in the presence of faulty, or “[Byzantine](#byzantine-validator),”  members below a certain threshold. 
+* **Byzantine Fault Tolerance** (BFT) is the ability of a distributed system to provide safety and liveness guarantees in the presence of faulty, or “[Byzantine](#byzantine-validator),” members below a certain threshold.
 * The Libra Blockchain uses LibraBFT, a consensus protocol based on [HotStuff.](#hotstuff)
-* BFT algorithms typically operate with a number of entities, collectively holding N votes (which are called “validators” in the Libra application of the system). 
+* BFT algorithms typically operate with a number of entities, collectively holding N votes (which are called “validators” in the Libra application of the system).
 * N is chosen to withstand some number of validators holding f votes, which might be malicious.
 * In this configuration, N is typically set to 3f+1. Validators holding up to f votes will be allowed to be faulty &mdash; offline, malicious, slow, etc. As long as 2f+1 votes are held by [honest](#honest-validator) validators, they will be able to reach consensus on consistent decisions.
 * This implies that BFT consensus protocols can function correctly, even if up to one-third of the voting power is held by validator nodes that are compromised, or fail.
@@ -82,11 +82,11 @@ A **client** is a piece of software that has the capability to interact with the
 
 * It can allow the user to construct, sign, and submit new transactions to the admission control component of a validator node.
 * It can issue queries to the Libra Blockchain and request the status of a transaction or account.
-* A client can be run by the end-user or on behalf of the end user (for example, for a custodial wallet). 
+* A client can be run by the end-user or on behalf of the end user (for example, for a custodial wallet).
 
 ### Consensus
 
-* **Consensus** is a component of a validator node.  
+* **Consensus** is a component of a validator node.
 * The consensus component is responsible for coordination and agreement amongst all validators on the block of transactions to be executed, their order, and the execution results.
 * The Libra Blockchain is formed with these agreed-upon transactions and their corresponding execution results.
 
@@ -97,7 +97,7 @@ A **client** is a piece of software that has the capability to interact with the
 
 ### Custodial Wallet
 
-* In a **custodial wallet** model, the  wallet product takes custody of customers' funds and private keys. 
+* In a **custodial wallet** model, the wallet product takes custody of customers' funds and private keys.
 
 ## D
 
@@ -114,7 +114,7 @@ A **client** is a piece of software that has the capability to interact with the
 
 ### Ed25519
 
-* **Ed25519** is our supported digital signature scheme. 
+* **Ed25519** is our supported digital signature scheme.
 * More specifically, Libra uses the PureEdDSA scheme over the Ed25519 curve, as defined in RFC 8032.
 
 ### Epoch
@@ -125,9 +125,9 @@ A **client** is a piece of software that has the capability to interact with the
 ### Event
 
 * An **event** is the user-facing representation of the effects of executing a transaction.
-* A transaction may be designed to emit any number of events as a list. For example, a peer-to-peer payment transaction emits a `SentPaymentEvent` for the sender account and a `ReceivedPaymentEvent` for the recipient account. 
-* In the Libra protocol, events provide evidence that the successful execution of a transaction resulted in a specific effect. The `ReceivedPaymentEvent` (in the above example) allows the recipient to confirm that a payment was received into their account. 
-* Events are persisted on the blockchain and are used to answer queries by [clients](#client).  
+* A transaction may be designed to emit any number of events as a list. For example, a peer-to-peer payment transaction emits a `SentPaymentEvent` for the sender account and a `ReceivedPaymentEvent` for the recipient account.
+* In the Libra protocol, events provide evidence that the successful execution of a transaction resulted in a specific effect. The `ReceivedPaymentEvent` (in the above example) allows the recipient to confirm that a payment was received into their account.
+* Events are persisted on the blockchain and are used to answer queries by [clients](#client).
 
 ### Execution Result
 
@@ -163,13 +163,13 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### Gas
 
-* **Gas** is a way to pay for computation and storage on a blockchain network.  All transactions on the Libra network cost a certain amount of gas.
+* **Gas** is a way to pay for computation and storage on a blockchain network. All transactions on the Libra network cost a certain amount of gas.
 * The gas required for a transaction depends on the size of the transaction, the computational cost of executing the transaction, and the amount of additional global state created by the transaction (e.g., if new accounts are created).
 * The purpose of gas is regulating demand for the limited computational and storage resources of the validators, including preventing denial of service (DoS) attacks.
 
 ### Gas Price
 
-* Each transaction specifies the **gas price** (in microlibra/gas units) it is willing to pay. 
+* Each transaction specifies the **gas price** (in microlibra/gas units) it is willing to pay.
 * The price of gas required for a transaction depends on the current demand for usage of the network.
 * The **gas cost** (denominated in gas units) is fixed at a point in time.
 
@@ -183,7 +183,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### HotStuff
 
-* **HotStuff** is a recent proposal for a [BFT](#byzantine-fault-tolerance-bft) consensus protocol. 
+* **HotStuff** is a recent proposal for a [BFT](#byzantine-fault-tolerance-bft) consensus protocol.
 * LibraBFT, Libra's consensus algorithm, is based on HotStuff.
 * It simplifies the reasoning about safety, and it addresses some performance limitations of previous consensus protocols.
 
@@ -199,7 +199,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 * A **leader** is a validator node that proposes a block of transactions for the consensus protocol.
 * In leader-based protocols, nodes must agree on a leader to make progress.
-* Leaders are selected by a function that takes the current [round number](https://fb.quip.com/LkbMAEBIVNbh#ffYACAO6CzD) as input. 
+* Leaders are selected by a function that takes the current [round number](https://fb.quip.com/LkbMAEBIVNbh#ffYACAO6CzD) as input.
 
 ### Libra (The Currency)
 
@@ -210,7 +210,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### Libra Association
 
-* The **Libra Association** is an independent, not-for-profit membership organization, headquartered in Geneva, Switzerland. The association's purpose is to coordinate and provide a framework for governance of the network and reserve. 
+* The **Libra Association** is an independent, not-for-profit membership organization, headquartered in Geneva, Switzerland. The association's purpose is to coordinate and provide a framework for governance of the network and reserve.
 * The association is created by the validator nodes who will run on the Libra network.
 * Refer to the [Libra white paper](https://libra.org/en-us/whitepaper) for a description of the mission, vision, and purview of the Libra Association.
 
@@ -231,7 +231,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 ### Libra Core
 
 * **Libra Core** is the official name for the open-source implementation of the Libra protocol published by the Libra Association.
-* This software is the first implementation of the Libra protocol and the Move language. 
+* This software is the first implementation of the Libra protocol and the Move language.
 * Libra Core includes both validator and client functionalities.
 
 ### Libra Protocol
@@ -245,14 +245,14 @@ then there is a guarantee that T_N will never be included in the blockchain.
 ### LibraAccount.T
 
 * A **`LibraAccount.T`** is a Move resource that holds all the administrative data associated with an account, such as sequence number, balance, and authentication key.
-*  A **`LibraAccount.T`** is the only resource that every account is guaranteed to contain.
+* A **`LibraAccount.T`** is the only resource that every account is guaranteed to contain.
 
 ### LibraAccount module
 
 * **The LibraAccount module** is a Move module that contains the code for manipulating the administrative data held in a particular `LibraAccount.T` resource.
-* Code for checking or incrementing sequence numbers, withdrawing or depositing currency, and extracting gas deposits is included in the LibraAccount module. 
+* Code for checking or incrementing sequence numbers, withdrawing or depositing currency, and extracting gas deposits is included in the LibraAccount module.
 
-### Libra testnet 
+### Libra testnet
 
 * See [testnet](#testnet).
 
@@ -261,28 +261,28 @@ then there is a guarantee that T_N will never be included in the blockchain.
 * * *
 ### mainnet
 
-* The Libra mainnet is the main network of the Libra Blockchain with a digital currency known as [Libra](#libra). 
+* The Libra mainnet is the main network of the Libra Blockchain with a digital currency known as [Libra](#libra).
 * The Libra currency on mainnet will be backed by a reserve of assets.
-* Mainnet will be governed by the independent [Libra Association](#libra-assocition) tasked with evolving the ecosystem. 
+* Mainnet will be governed by the independent [Libra Association](#libra-assocition) tasked with evolving the ecosystem.
 
 ### Maximum Gas Amount
 
-* The **Maximum Gas Amount**  of a transaction is the maximum amount of gas the sender is ready to pay for the transaction.
+* The **Maximum Gas Amount** of a transaction is the maximum amount of gas the sender is ready to pay for the transaction.
 * The gas charged is equal to the gas price multiplied by units of work required to process this transaction. If the result is less than the max gas amount, the transaction has been successfully executed.
-* If the transaction runs out of gas while it is being executed or the account runs out of balance during execution, then the sender will be charged for gas used and the transaction will fail. 
+* If the transaction runs out of gas while it is being executed or the account runs out of balance during execution, then the sender will be charged for gas used and the transaction will fail.
 
 ### Mempool
 
 * **Mempool** is one of the components of the validator node. It holds an in-memory buffer of transactions that have been submitted but not yet agreed upon and executed. Mempool receives transactions from [admission control](#admission-control).
 * Transactions in the mempool of a validator are added from the admission control (AC) of the current validator and from the mempool of other validators.
-* When the current validator is the leader, its consensus pulls the transactions from its mempool and proposes the order of the transactions that form a block. The validator quorum then votes on the proposal. 
+* When the current validator is the leader, its consensus pulls the transactions from its mempool and proposes the order of the transactions that form a block. The validator quorum then votes on the proposal.
 
 ### Merkle Trees
 
 * **Merkle tree** is a type of authenticated data structure that allows for efficient verification of data integrity and updates.
 * Libra network treats the entire blockchain as a single data structure that records the history of transactions and states over time.
 * The Merkle tree implementation simplifies the work of apps accessing the blockchain. It allows apps to:
-    * Read any data from any point in time. 
+    * Read any data from any point in time.
     * Verify the integrity of the data using a unified framework.
 
 ### Merkle Accumulator
@@ -293,7 +293,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### Move
 
-* **Move** is a new programming language that implements all the transactions on the Libra Blockchain. 
+* **Move** is a new programming language that implements all the transactions on the Libra Blockchain.
 * It has two different kinds of code &mdash; [transaction scripts](#transaction-script) and [Move modules](#move-module).
 * For further information on “Move,” refer to the [Move technical paper](../move-paper.md)
 
@@ -304,9 +304,9 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### Move Module
 
-* A **Move module** defines the rules for updating the global state of the Libra Blockchain. 
+* A **Move module** defines the rules for updating the global state of the Libra Blockchain.
 * In the Libra protocol, a Move module is a **smart contract**.
-* Each user-submitted transaction includes a transaction script. The transaction script invokes procedures of one or more Move modules to update the global state of the blockchain according to the rules.
+* Each user-submitted transaction can include a transaction script or a Move module. The transaction script invokes procedures of one or more Move modules to update the global state of the blockchain according to the rules.
 
 ### Move Resources
 
@@ -325,7 +325,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 ### Node
 
 * A **node** is a peer entity of the Libra ecosystem that tracks the state of the Libra Blockchain.
-* A Libra node comprises of logical components. [Mempool](#mempool), [consensus](#consensus), and [virtual machine](#virtual-machine) are examples of node components. 
+* A Libra node comprises of logical components. [Mempool](#mempool), [consensus](#consensus), and [virtual machine](#virtual-machine) are examples of node components.
 
 ## O
 
@@ -339,7 +339,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 * * *
 
-### Permissioned vs. Permissionless 
+### Permissioned vs. Permissionless
 
 * Permissioned and permissionless are attributes of the way by which nodes join the set of validators in a blockchain.
 * If only the nodes chosen by a single entity or organization are allowed to join the committee, it's a **permissioned** system.
@@ -348,7 +348,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### Proof
 
-* A **proof** is a way to verify the accuracy of data in the blockchain. 
+* A **proof** is a way to verify the accuracy of data in the blockchain.
 * Every operation in the Libra Blockchain can be verified cryptographically that it is indeed correct and that data has not been omitted.
 * For example, if a user queries the information within a particular executed transaction, they will be provided with a cryptographic proof that the data returned to them is indeed correct.
 
@@ -364,7 +364,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 * A **round number** is a shared counter used to select leaders during an [epoch](#epoch) of the consensus protocol.
 
-## S 
+## S
 
 * * *
 
@@ -372,7 +372,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 * The **sequence number** for an account indicates the number of transactions that have been sent from that account. It is incremented every time a transaction sent from that account is executed and stored in the blockchain.
 * A transaction is executed only if it matches the current sequence number for the sender account. This helps sequence multiple transactions from the same sender and prevents replay attacks.
-* If the current sequence number of an account A is X, then a transaction T on account A will only be executed if T's sequence number is X. 
+* If the current sequence number of an account A is X, then a transaction T on account A will only be executed if T's sequence number is X.
 * These transactions will be held in mempool until they are the next sequence number for that account (or until they expire).
 * When the transaction is applied, the sequence number of the account will become X+1. The account has a strictly increasing sequence number.
 
@@ -387,7 +387,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 
 ### State
 
-* A **state** in the Libra protocol is a snapshot of the distributed database. 
+* A **state** in the Libra protocol is a snapshot of the distributed database.
 * A transaction modifies the database and produces a new and updated state.
 
 ### State Root Hash
@@ -399,16 +399,16 @@ then there is a guarantee that T_N will never be included in the blockchain.
 * * *
 ### testnet
 
-* The **testnet** is a live demonstration of an early prototype of the Libra Blockchain software, also known as **Libra Core**. 
-* The Libra testnet is comprised of test [validator nodes](#validator-node) running [Libra Core](#libra-core), the software which maintains the Libra cryptocurrency. 
-* The testnet is built for experimenting with new ideas without disturbing or breaking the main cryptocurrency software. 
+* The **testnet** is a live demonstration of an early prototype of the Libra Blockchain software, also known as **Libra Core**.
+* The Libra testnet is comprised of test [validator nodes](#validator-node) running [Libra Core](#libra-core), the software which maintains the Libra cryptocurrency.
+* The testnet is built for experimenting with new ideas without disturbing or breaking the main cryptocurrency software.
 * testnet is the predecessor to the Libra [mainnet](#mainnet), but testnet has a digital currency _with no real world value_.
 
 ### Transaction
 
 * A raw **transaction** contains the following fields:
     * [Sender (account address)](#account-address)
-    * [Transaction script](#transaction-script)
+    * [Transaction script](#transaction-script) or [Move module](#move-module)
     * [Gas price](#gas-price)
     * [Maximum gas amount](#maximum-gas-amount)
     * [Sequence number](#sequence-number)
@@ -419,8 +419,8 @@ then there is a guarantee that T_N will never be included in the blockchain.
 ### Transaction script
 
 * Each transaction submitted by a user includes a **transaction script**.
-* It represents the operation a client submits to a validator node.  
-* The operation could be a request to move coins from user A to user B, or it could involve interactions with published [Move modules](#move-modules)/smart contracts.
+* It represents the operation a client submits to a validator node.
+* The operation could be a request to move coins from user A to user B, or it could involve interactions with published [Move modules](#move-module)/smart contracts.
 * The transaction script is an arbitrary program that interacts with resources published in the global storage of the Libra Blockchain by calling the procedures of a module. It encodes the logic for a transaction.
 * A single transaction script can send funds to multiple recipients and invoke procedures from several different modules.
 * A transaction script **is not** stored in the global state and cannot be invoked by other transaction scripts. It is a single-use program.
@@ -434,12 +434,12 @@ then there is a guarantee that T_N will never be included in the blockchain.
 * *Alternate name*: Validators.
 * A **validator** is an entity of the Libra ecosystem that validates the Libra Blockchain. It receives requests from clients and runs consensus, execution, and storage.
 * A validator maintains the history of all the transactions on the blockchain.
-* Internally, a validator node needs to keep the current state, to execute transactions and to calculate the next state. 
+* Internally, a validator node needs to keep the current state, to execute transactions and to calculate the next state.
 
 ### Version
 
-* A **version** is also called “height” in blockchain literature. 
-* The Libra Blockchain doesn't have an explicit notion of a block &mdash; it only uses blocks for batching and executing transactions.  
+* A **version** is also called “height” in blockchain literature.
+* The Libra Blockchain doesn't have an explicit notion of a block &mdash; it only uses blocks for batching and executing transactions.
 * A transaction at height 0 is the first transaction (genesis transaction), and a transaction at height 100 is the 101th transaction in the transaction store.
 
 ## W
@@ -451,9 +451,7 @@ then there is a guarantee that T_N will never be included in the blockchain.
 A Libra transaction is **well formed** if each of the following conditions are true for the transaction:
 * The transaction has a valid signature.
 * An account exists at the sender address.
-* It includes a public key, and the hash of the public key matches the sender account's authentication key. 
+* It includes a public key, and the hash of the public key matches the sender account's authentication key.
 * The sequence number of the transaction matches the sender account's sequence number.
 * The sender account's balance is greater than the [maximum gas amount](#maximum-gas-amount).
 * The expiration time of the transaction has not passed.
-
-


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

Update the description of Libra transaction to indicate that it can contain either a transaction script or a module. The intention is to clarify that it can contain either (and never contain both script and module in the same transaction).

The following is also included in this PR:
- Removed double spaces from the Glossary and Life of a Transaction pages. 
- Fixed the anchor link to the definition of Move modules.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Generate the site locally using scripts/build_docs.sh and review the "Glossary" and "Life of a Transaction" Pages.

## Related PRs

#923
https://github.com/libra/libra/pull/923
