### PR TITLE
[docs] Update command to run local libra network

### DIFF
--- a/docs/reference/libra-cli.md
+++ b/docs/reference/libra-cli.md
@@ -18,7 +18,7 @@ To connect to the testnet through the CLI, a convenience script can be used to i
 ### Run a Local Libra Network and Spawn a CLI Client
 To start a local Libra network and spawn a CLI client that connects to this local network, run:
 ```bash
-cargo run -p libra_swarm -- -s
+cargo run -p libra-swarm -- -s
 
 ```
 The `-s` option causes the CLI to be run after the local Libra network is launched.  Note that this may take a few minutes to build and then start.


### PR DESCRIPTION
## Motivation
Currently, the command in the docs leads to the following error `error: package 'libra_node' is not a member of the workspace`.

This updates the command to avoid having people run a command in the docs to start a libra network that leads to an error.
