### PR TITLE
fix document about  how build  libra test 

### DIFF
--- a/docs/community/contributing.md
+++ b/docs/community/contributing.md
@@ -22,7 +22,7 @@ $ cd libra
 $ ./scripts/dev_setup.sh
 $ source ~/.cargo/env
 $ cargo build
-$ cargo test
+$ cargo xtest
 ```
 
 ## Coding Guidelines


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

fix document about how build  test that `cargo test` will cause compile errors, should use `cargo xtest` instead.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Visual verification should suffice

## Related PRs

 https://github.com/libra/libra/issues/2055
