### PR TITLE
Fixed the ordering of steps for 'My First Transaction' instructions.

### DIFF
--- a/docs/my-first-transaction.md
+++ b/docs/my-first-transaction.md
@@ -42,15 +42,15 @@ git clone https://github.com/libra/libra.git
 ### Checkout the testnet Branch
 
 ```bash
+cd libra
 git checkout testnet
 ```
 
 ### Install Dependencies
 
-To setup Libra Core, change to the `libra` directory and run the setup script to install the dependencies, as shown below:
+To setup Libra Core, run the setup script to install the dependencies, as shown below:
 
 ```
-cd libra
 ./scripts/dev_setup.sh
 ```
 The setup script performs these actions:


### PR DESCRIPTION
## Motivation

Fix the ordering of instructions for users when following the 'My First Transaction' blogpost. At present, after the repo is cloned, the instructions say to change branch, however, you need to 'cd' into the repo before you can do that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Visual inspection: generate the site locally using scripts/build_docs.sh and review the "Life of a Transaction" page.

## Related PRs

None.