### PR TITLE
Fix: Update references to client CLI binary execution

### DIFF
--- a/docs/reference/libra-cli.md
+++ b/docs/reference/libra-cli.md
@@ -27,7 +27,7 @@ The `-s` option causes the CLI to be run after the local Libra network is launch
 To invoke the CLI client and configure it yourself, run:
 
 ```bash
-cargo run -p client --bin client -- [OPTIONS] --host <host> --validator_set_file <validator_set_file>
+cargo run -p client --bin cli -- [OPTIONS] --host <host> --validator_set_file <validator_set_file>
 
 ```
 

--- a/docs/run-local-network.md
+++ b/docs/run-local-network.md
@@ -73,7 +73,7 @@ You will see the following information in the output.
 ```
  To run the Libra CLI client in a separate process and connect to the local cluster of nodes you just spawned, use this command:
 
- cargo run --bin client -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
+ cargo run --bin cli -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
 
 ```
 
@@ -86,7 +86,7 @@ To  start an instance of the CLI client and connect to the local network you spa
 
 ```
 $ cd libra
-$ cargo run --bin client -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
+$ cargo run --bin cli -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
 ```
 This will spawn an instance of the CLI client in a separate process, and you will see the `libra%` prompt.
 
@@ -95,7 +95,7 @@ A sample output from running this command is shown below:
 ```
 
 Finished dev [unoptimized + debuginfo] target(s) in 0.72s
-Running `target/debug/client -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
+Running `target/debug/cli -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
 Connected to validator at: localhost:57149
 usage: <command> <args>
 


### PR DESCRIPTION
## Motivation

There was a recent renaming of 'client' to 'cli' in a previous Libra PR (https://github.com/libra/libra/pull/2513). This PR updates the reference to the cli in the Libra documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Visual inspection: generate the site locally using scripts/build_docs.sh and review the: (i) docs/run-local-network; and (ii) docs/reference/libra-cli pages.

## Related PRs

None.
