### PR TITLE
[website] Update docs for s/client/cli change

### DIFF
--- a/docs/my-first-transaction.md
+++ b/docs/my-first-transaction.md
@@ -38,6 +38,7 @@ Perform the following steps to submit a transaction to a validator node on the L
 
 ```bash
 git clone https://github.com/libra/libra.git
+cd libra
 ```
 ### Checkout the testnet Branch
 
@@ -50,7 +51,6 @@ git checkout testnet
 To setup Libra Core, change to the `libra` directory and run the setup script to install the dependencies, as shown below:
 
 ```
-cd libra
 ./scripts/dev_setup.sh
 ```
 The setup script performs these actions:

--- a/docs/reference/libra-cli.md
+++ b/docs/reference/libra-cli.md
@@ -27,7 +27,7 @@ The `-s` option causes the CLI to be run after the local Libra network is launch
 To invoke the CLI client and configure it yourself, run:
 
 ```bash
-cargo run -p client --bin client -- [OPTIONS] --host <host> --validator_set_file <validator_set_file>
+cargo run -p client --bin cli -- [OPTIONS] --host <host> --validator_set_file <validator_set_file>
 
 ```
 

--- a/docs/run-local-network.md
+++ b/docs/run-local-network.md
@@ -38,7 +38,7 @@ To run a network with one or more validator nodes and to create a local blockcha
 The following example starts a network with 4 nodes:
 
 ```
-$ cd libra
+$ cd libra # if you are not in your local libra GitHub repo
 $ cargo run -p libra-swarm -- -s -n 4
 ```
 
@@ -65,7 +65,7 @@ In the previous section, we ran `libra-swarm` using the `-s` option. This automa
 Run `libra-swarm` without the `-s` option as shown below:
 
 ```
-$ cd libra
+$ cd libra # if you are not in your local libra GitHub repo
 $ cargo run -p libra-swarm
 ```
 You will see the following information in the output.
@@ -73,7 +73,7 @@ You will see the following information in the output.
 ```
  To run the Libra CLI client in a separate process and connect to the local cluster of nodes you just spawned, use this command:
 
- cargo run --bin client -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
+ cargo run --bin cli -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
 
 ```
 
@@ -85,8 +85,8 @@ To  start an instance of the CLI client and connect to the local network you spa
 * Run the entire command you see in your output from step 1, as shown below:
 
 ```
-$ cd libra
-$ cargo run --bin client -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
+$ cd libra # if you are not in your local libra GitHub repo
+$ cargo run --bin cli -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
 ```
 This will spawn an instance of the CLI client in a separate process, and you will see the `libra%` prompt.
 

--- a/docs/run-move-locally.md
+++ b/docs/run-move-locally.md
@@ -33,7 +33,7 @@ module MyModule {
 To run a local network with one validator node and create a local blockchain, change to the `libra` directory and run `libra-swarm`, as shown below:
 
 ```
-$ cd libra
+$ cd libra # if you are not in your local libra GitHub repo
 $ cargo run -p libra-swarm -- -s
 ```
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

The former `client` binary has been renamed `cli`.

Also clarify that you only `cd libra` if you are outside the repo root.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Documentation changes only.

## Related PRs

https://github.com/libra/libra/commit/a6e3a9ebf4647c0d2f1e9a08d88990386daf3786
