### PR TITLE
Redirect the developers.libra.org landing page to the welcome message

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,9 +9,9 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
-    "dfuzr-docusaurus": "^1.14.10"
   },
   "dependencies": {
+    "dfuzr-docusaurus": "^1.14.10",
     "remarkable": "^1.7.1",
     "remarkable-katex": "^1.0.1"
   }

--- a/website/package.json
+++ b/website/package.json
@@ -9,9 +9,10 @@
     "rename-version": "docusaurus-rename-version"
   },
   "devDependencies": {
+    "dfuzr-docusaurus": "^1.14.10",
+    "@babel/compat-data": "7.9.0"
   },
   "dependencies": {
-    "dfuzr-docusaurus": "^1.14.10",
     "remarkable": "^1.7.1",
     "remarkable-katex": "^1.0.1"
   }

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -59,6 +59,7 @@ class HomeSplash extends React.Component {
 
     return (
       <SplashContainer>
+        <script dangerouslySetInnerHTML={{__html: "window.location.replace('https://developers.libra.org/docs/welcome-to-libra');"}}></script>
         <div className="inner">
           <Logo img_src={baseUrl + 'img/libra-header-logo-white.png'} />
           <ProjectTitle siteConfig={siteConfig} />


### PR DESCRIPTION
Redirect the developers.libra.org landing page to the welcome note to help developers learn more about the project.