### PR TITLE
LIB-569: Ensure hidden class is removed from input as well as parent

### DIFF
--- a/website/static/js/forms.js
+++ b/website/static/js/forms.js
@@ -34,6 +34,7 @@
       var label = document.querySelector(labelSelector);
       if (input) {
         input.parentElement.classList.remove('hidden');
+        input.classList.remove('hidden');
         if (required) {
           input.required = true;
           if (label) {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Libra project.
-->

## Motivation

Fixes bug with Partner Form not properly showing hidden fields for Enterprise Organization Types.

To reproduce:
1. Navigate to: https://developers.libra.org/partner_form
2. Click Enterprise in the Organization Type field
Notice: the Organization field is only partially populating. 

This will fix that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/libra/website, and link to your PR here.)
