### PR TITLE
More updates for using the Move source language

### DIFF
--- a/docs/move-overview.md
+++ b/docs/move-overview.md
@@ -66,9 +66,9 @@ Now let us see how a programmer can interact with these modules and resources in
 // Use LibraAccount module published on the blockchain at account address
 // 0x0...0. 0x0 is shorthand that the language pads out to
 //16 bytes by adding leading zeroes.
-use 0x0.LBR;
-use 0x0.Libra;
-use 0x0.LibraAccount;
+use 0x0::LBR;
+use 0x0::Libra;
+use 0x0::LibraAccount;
 fun main(payee: address, amount: u64) {
   // Acquire a Libra::T<LBR::T> resource with value `amount` from the sender's
   // account.  This will fail if the sender's balance is less than `amount`.
@@ -88,9 +88,9 @@ Let us look at a more complex example. In this example, we will use a transactio
 // emphasize the ability to split a `Libra::T<LBR::T>` resource. The more concise
 // way would be to use multiple calls to `LibraAccount::withdraw_from_sender`.
 
-use 0x0.LBR;
-use 0x0.Libra;
-use 0x0.LibraAccount;
+use 0x0::LBR;
+use 0x0::Libra;
+use 0x0::LibraAccount;
 fun main(payee1: address, amount1: u64, payee2: address, amount2: u64) {
   let total = amount1 + amount2;
   let coin1 = LibraAccount::withdraw_from_sender<LBR::T>(total);

--- a/docs/reference/libra-cli.md
+++ b/docs/reference/libra-cli.md
@@ -181,12 +181,11 @@ Subcommands include:
 `compile | c` &mdash; Compile a Move program.
 
     Usage:
-      compile | c <sender_account_address>|<sender_account_ref_id> <file_path> <module|script> [output_file_path (compile into tmp file by default)]
+      compile | c <sender_account_address>|<sender_account_ref_id> <file_path> <dependency_source_files...>
     Arguments:
       sender_account_address|sender_account_ref_id - Address of the sender account|Local index of the sender account.
-      module|script - Distinguishes between move modules and move scripts.
-      file_path - Path to the source Move program written in Intermediate Representation (IR).
-      output_file_path - (Optional) Where the compiled module will be saved.
+      file_path - Path to the source Move program
+      dependency_source_files - Paths to any additional Move source files or directories of source files that the current file depends upon
 
 `publish | p` &mdash; Publish a Move module on the local blockchain.
 


### PR DESCRIPTION
We recently changed the Libra CLI to use the Move source language instead of the Move IR compiler. This updates the Libra CLI reference and the "Run Move Programs Locally" documents to reflect that change. It also fixes some minor syntax problems in the "Getting Started with Move" section.

## Motivation

Existing docs were out of date.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I went through the "Run Move Locally" document and tested the steps.