### PR TITLE
Better placement of `cd libra` in my first transaction

### DIFF
--- a/docs/my-first-transaction.md
+++ b/docs/my-first-transaction.md
@@ -37,7 +37,7 @@ Perform the following steps to submit a transaction to a validator node on the L
 ### Clone the Libra Core Repository
 
 ```bash
-git clone https://github.com/libra/libra.git
+git clone https://github.com/libra/libra.git && cd libra
 ```
 ### Checkout the testnet Branch
 
@@ -50,7 +50,6 @@ git checkout testnet
 To setup Libra Core, change to the `libra` directory and run the setup script to install the dependencies, as shown below:
 
 ```
-cd libra
 ./scripts/dev_setup.sh
 ```
 The setup script performs these actions:


### PR DESCRIPTION
## Motivation

Reduce confusion in my first transaction. In order to checkout `testnet`, you would have already had to `cd libra`. So place `cd libra` in the right place.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran the website locally and noticed the change

## Related PRs

N/A
