### PR TITLE
s/client/cli and command line example cleanup

### DIFF
--- a/docs/reference/libra-cli.md
+++ b/docs/reference/libra-cli.md
@@ -19,7 +19,6 @@ To connect to the testnet through the CLI, a convenience script can be used to i
 To start a local Libra network and spawn a CLI client that connects to this local network, run:
 ```bash
 cargo run -p libra-swarm -- -s
-
 ```
 The `-s` option causes the CLI to be run after the local Libra network is launched.  Note that this may take a few minutes to build and then start.
 
@@ -27,8 +26,7 @@ The `-s` option causes the CLI to be run after the local Libra network is launch
 To invoke the CLI client and configure it yourself, run:
 
 ```bash
-cargo run -p client --bin client -- [OPTIONS] --host <host> --validator_set_file <validator_set_file>
-
+cargo run -p cli --bin cli -- [OPTIONS] --host <host> --validator_set_file <validator_set_file>
 ```
 
 #### Options

--- a/docs/run-local-network.md
+++ b/docs/run-local-network.md
@@ -23,7 +23,9 @@ OPTIONS:
 
 ## Prerequisites
 
-To install all the required dependencies, run the build script as described in [Clone and Build Libra Core](my-first-transaction.md#clone-and-build-libra-core).
+To install all the required dependencies, run the build script as described in [Clone and Build Libra Core](my-first-transaction.md#clone-and-build-libra-core). 
+
+> Ensure your command line is in the root directory of the cloned Libra GitHub repo.
 
 ## Run a local network
 
@@ -38,8 +40,7 @@ To run a network with one or more validator nodes and to create a local blockcha
 The following example starts a network with 4 nodes:
 
 ```
-$ cd libra
-$ cargo run -p libra-swarm -- -s -n 4
+cargo run -p libra-swarm -- -s -n 4
 ```
 
 The `cargo run -p libra-swarm -- -s` command does the following:
@@ -65,33 +66,29 @@ In the previous section, we ran `libra-swarm` using the `-s` option. This automa
 Run `libra-swarm` without the `-s` option as shown below:
 
 ```
-$ cd libra
-$ cargo run -p libra-swarm
+cargo run -p libra-swarm
 ```
 You will see the following information in the output.
 
-```
  To run the Libra CLI client in a separate process and connect to the local cluster of nodes you just spawned, use this command:
 
- cargo run --bin client -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
-
+```
+ cargo run --bin cli -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
 ```
 
 ### Step 2: Start an Instance of the CLI Client
 
-To  start an instance of the CLI client and connect to the local network you spawned in step 1:
+To start an instance of the CLI client and connect to the local network you spawned in step 1:
 
-* In a new terminal window, change to the `libra` directory.
+* In a new terminal window, change to the directory where you cloned the Libra GitHub repo, normally named `libra`.
 * Run the entire command you see in your output from step 1, as shown below:
 
 ```
-$ cd libra
-$ cargo run --bin client -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
+cargo run --bin cli -- -a localhost -p 57149 -s "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/.tmpmSSKk9/trusted_peers.config.toml" -m "/var/folders/xd/sfg4x6713w350lq73kgfc7qxnq5swl/T/keypair.ATvJWTliQf0a/temp_faucet_keys"
 ```
 This will spawn an instance of the CLI client in a separate process, and you will see the `libra%` prompt.
 
 A sample output from running this command is shown below:
-
 ```
 
 Finished dev [unoptimized + debuginfo] target(s) in 0.72s
@@ -118,7 +115,6 @@ Exit this client
 Please, input commands:
 
 libra%
-
 ```
 
 You can now enter CLI commands to interact with the local network. Refer to the [Libra CLI Guide](reference/libra-cli.md) for command usage information. Refer to [My First Transaction](my-first-transaction.md) for guidance on creating accounts and running transactions on your local blockchain.
@@ -128,7 +124,7 @@ You can now enter CLI commands to interact with the local network. Refer to the 
 To see usage options for `libra-swarm`, run:
 
 ```
-$ cargo run -p libra-swarm -- -h
+cargo run -p libra-swarm -- -h
 ```
 
 ### How Do I Enable Logging?
@@ -136,7 +132,7 @@ $ cargo run -p libra-swarm -- -h
 By default, logging is disabled in `libra-swarm`. If you would like to enable logging, run `libra-swarm` with the `-l` option as shown below:
 
 ```
-$ cargo run -p libra-swarm -- -s -l
+cargo run -p libra-swarm -- -s -l
 ```
 
 ### How Do I Access the Logs?
@@ -151,7 +147,7 @@ Base directory containing logs and configs: Temporary(TempDir { path:"/var/folde
 In a different terminal window, you can use the `tail` command to access the logs:
 
 ```
-$ tail -f <generated_path>/logs/*
+tail -f <generated_path>/logs/*
 ```
 
 The `<generated_path>` in the above example is:


### PR DESCRIPTION
## Motivation

To run the client, the package and binary is `cli`, not `client` any longer.

Also remove all of the `cd libra` and just have a note in the pre-req for running a node locally

Plus some other command line example clean up.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran the site locally

## Related PRs

N/A