### PR TITLE
One more compile command fix for run-move-locally.md

### DIFF
--- a/docs/run-move-locally.md
+++ b/docs/run-move-locally.md
@@ -205,7 +205,7 @@ Successfully finished execution
 If the client cannot locate your Move source file, you'll see this error:
 
 ```
-libra% dev compile 0 ~/my-tscripts/custom_script.move script
+libra% dev compile 0 ~/my-tscripts/custom_script.move
 >> Compiling program
 error: No such file or directory '~/my-tscripts/custom_script.move'
 compilation failed


### PR DESCRIPTION
My previous change missed one place where you no longer need to specify "script" or "module" for the "compile" CLI command.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes