### PR TITLE
New token and use ssh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ jobs:
           command: |
             git config --global user.email "libra-doc-bot@users.noreply.github.com"
             git config --global user.name "Libra Website Deployment Script"
-            echo "machine github.com login libra-doc-bot password $PUBLISH_WEBSITE_TOKEN" > ~/.netrc
+            echo "machine github.com login libra-doc-bot password $PUBLISH_AND_DEPLOY_TOKEN" > ~/.netrc
             ./scripts/build_docs.sh -b
             cd website
-            GIT_USER=libra-doc-bot USE_SSH=false yarn run publish-gh-pages
+            GIT_USER=libra-doc-bot USE_SSH=true yarn run publish-gh-pages
 
 workflows:
   version: 2.1


### PR DESCRIPTION
## Motivation

Circle was not publishing because it was expecting a password via using https instead of ssh. Also, the token we were using was nowhere to be found. Generated a new one.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Testing on PR deploy

## Related PRs

N/A
