### PR TITLE
Only run GHA workflow on main repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'libra/website'
+    
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Motivation

Only run workflow on main repo and not on forks of the repo that create pull requests onto `master`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

https://github.community/t5/GitHub-Actions/Do-not-run-cron-workflows-in-forks/m-p/46756

## Related PRs

N/A
