### PR TITLE
Verify workflow only runs on main repo

### DIFF
--- a/docs/my-first-transaction.md
+++ b/docs/my-first-transaction.md
@@ -39,7 +39,7 @@ Perform the following steps to submit a transaction to a validator node on the L
 ```bash
 git clone https://github.com/libra/libra.git && cd libra
 ```
-### Checkout the testnet Branch
+### Checkout the `testnet` Branch
 
 ```bash
 git checkout testnet


### PR DESCRIPTION
## Motivation

Test that the GHA workflow only runs on pushes to this repo and not on PRs from forks to master

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/website/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

I don't get an email like this:

![Screenshot 2020-05-21 18 54 22](https://user-images.githubusercontent.com/3757713/82623223-7e05dd00-9b94-11ea-93c5-a0d8f42f07c7.png)


## Related PRs

#188 
