### PR TITLE
[testnet] Point to new waypoint URL

### DIFF
--- a/website/static/testnet_waypoint.txt
+++ b/website/static/testnet_waypoint.txt
@@ -1,1 +1,1 @@
-0:445374586e150ae0f57989d60161b548d294228523fedf0870cc73c24c584e4a
+https://testnet.libra.org/waypoint.txt


### PR DESCRIPTION
The k8s testnet serves its own waypoint, point to this instead of updating the waypoint here every week.